### PR TITLE
Use `Object.create` for prototypical inheritance

### DIFF
--- a/src/b3.js
+++ b/src/b3.js
@@ -263,16 +263,18 @@ b3.Class = function(baseClass) {
     // create a new class
     var cls = function(params) {
         this.initialize(params);
-    }
+    };
     
     // if base class is provided, inherit
     if (baseClass) {
-        cls.prototype = new baseClass();
+        cls.prototype = Object.create(baseClass.prototype);
         cls.prototype.constructor = cls;
     }
     
     // create initialize if does not exist on baseClass
-    cls.prototype.initialize = cls.prototype.initialize || function() {};
+    if(!cls.prototype.initialize) {
+        cls.prototype.initialize = function() {};
+    }
 
     return cls;
 }


### PR DESCRIPTION
Creating class instances as prototypes for subclasses can have unwanted side-effects. Also currently `BaseNode.initialize` is called multiple times per node (once for `new baseNode()` and from the `initialize` method of the subclass, e.g. `Action`).
All major browsers support `Object.create` now, which is the preferred method.

Also I removed the assignment of `initialize` to `cls.prototype.initialize` as it is not necessary. 

Tell me, if you need any adjustments! :)
