### PR TITLE
Add custom Node type when importing trees

### DIFF
--- a/tools/editor/app/events.js
+++ b/tools/editor/app/events.js
@@ -146,6 +146,19 @@ app.events.onButtonNewTree = function(event) {
 app.events.onButtonImportTree = function(event) {
     var json = app.dom.importEntry.val();
     try {
+        var data = JSON.parse(json);
+        for (var id in data.nodes) {
+            var node = data.nodes[id];
+            console.log(node)
+            if (!app.view.nodes[node.name]) {
+                app.helpers.addCustomNode({
+                    name: node.name,
+                    title: node.title,
+                    //Try to guess the node type
+                    category: node.child ? "decorator" : (node.children ? "composite" : "action")
+                });
+            }
+        }
         app.view.importFromJSON(json);
     } catch (e) {
         app.helpers.alert('error', 'Bad input format, check the console to '+

--- a/tools/editor/app/helpers.js
+++ b/tools/editor/app/helpers.js
@@ -201,6 +201,24 @@ app.helpers.addCustomNodes = function(table) {
 
   app.helpers.updateNodes();
 }
+
+app.helpers.addCustomNode = function(option) {
+  var classes = {
+    'composite' : b3.Composite,
+    'decorator' : b3.Decorator,
+    'condition' : b3.Condition,
+    'action' : b3.Action,
+  };
+  var category = option.category;
+  var cls = classes[category];
+  
+  var tempClass = b3.Class(cls);
+  tempClass.prototype.name = option.name;
+  tempClass.prototype.title = option.title;
+  app.view.registerNode(tempClass);
+
+  app.helpers.updateNodes();
+};
 /* ========================================================================= */
 
 /* ========================================================================= */


### PR DESCRIPTION
###### Summary

Until now, every custome node types where deleted when you exit the page and you if you try to import a tree with custome node, you get an error.

With this version, importing a tree will create any custome node that doesn't exist yet. It will try to guess the node type from the json.
###### About the code

When importing a tree, we go through all nodes and check if the node names is allready registered, if not, we create it. Then we use the normal .importFromJSON methode.
